### PR TITLE
Potential fix for code scanning alert no. 45: Resource injection

### DIFF
--- a/XRayBuilder.Core/src/XRay/Logic/Export/XRayExporterSqlite.cs
+++ b/XRayBuilder.Core/src/XRay/Logic/Export/XRayExporterSqlite.cs
@@ -48,7 +48,12 @@ namespace XRayBuilder.Core.XRay.Logic.Export
         private SQLiteConnection Create(string path)
         {
             SQLiteConnection.CreateFile(path);
-            var db = new SQLiteConnection($"Data Source={path};Version=3;");
+            var connectionStringBuilder = new SQLiteConnectionStringBuilder
+            {
+                DataSource = path,
+                Version = 3
+            };
+            var db = new SQLiteConnection(connectionStringBuilder.ConnectionString);
             db.Open();
             string sql;
             try


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/xray-builder.gui/security/code-scanning/45](https://github.com/MjrTom/xray-builder.gui/security/code-scanning/45)

To fix the issue, we should use a safer method to construct the SQLite connection string. The `SQLiteConnectionStringBuilder` class can be used to safely include the `path` parameter in the connection string. This approach ensures that the input is properly escaped and prevents resource injection attacks.

The changes will involve:
1. Replacing the direct string interpolation with the use of `SQLiteConnectionStringBuilder` to construct the connection string.
2. Updating the `Create` method in `XRayExporterSqlite` to use the builder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
