### PR TITLE
Potential fix for code scanning alert no. 44: Resource injection

### DIFF
--- a/XRayBuilder/src/UI/Preview/frmPreviewXR.cs
+++ b/XRayBuilder/src/UI/Preview/frmPreviewXR.cs
@@ -33,7 +33,7 @@ namespace XRayBuilderGUI.UI.Preview
                 throw new Exception("Invalid X-Ray file.");
 
             var terms = ver == XRayUtil.XRayVersion.New
-                ? _termsService.ExtractTermsNew(new SQLiteConnection($"Data Source={filePath}; Version=3;"), true)
+                ? _termsService.ExtractTermsNew(new SQLiteConnection(new SQLiteConnectionStringBuilder { DataSource = filePath, Version = 3 }.ToString()), true)
                 : _termsService.ExtractTermsOld(filePath);
 
             flpPeople.Controls.Clear();


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/xray-builder.gui/security/code-scanning/44](https://github.com/MjrTom/xray-builder.gui/security/code-scanning/44)

To fix the issue, we should avoid directly concatenating user input into the SQLite connection string. Instead, we can use the `SQLiteConnectionStringBuilder` class, which safely constructs the connection string and escapes any special characters in the user input. This approach ensures that the connection string is not vulnerable to resource injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
